### PR TITLE
add .idea dir

### DIFF
--- a/src/Defaults.ts
+++ b/src/Defaults.ts
@@ -38,6 +38,7 @@ export const DefaultDirectories = new Set([
 	"examples",
 	"coverage",
 	".nyc_output",
+	".idea"
 ])
 
 // DefaultExtensions pruned.


### PR DESCRIPTION
Webstorm is saving cache to .idea folder.
Sometimes developers forget to add it to npm ignore.